### PR TITLE
Fixing #186

### DIFF
--- a/src/main/java/net/ilexiconn/jurassicraft/block/BlockAmberOre.java
+++ b/src/main/java/net/ilexiconn/jurassicraft/block/BlockAmberOre.java
@@ -23,22 +23,12 @@ public class BlockAmberOre extends Block
         setHardness(3.0F);
         setResistance(5.0F);
         setStepSound(Block.soundTypeStone);
-        setHarvestLevel("pickaxe", 1);
+        setHarvestLevel("pickaxe", 2);
         setCreativeTab(ModCreativeTabs.blocks);
     }
 
     public Item getItemDropped(int value, Random random, int thing)
     {
         return ModItems.amber;
-    }
-
-    public void harvestBlock(World world, EntityPlayer player, int x, int y, int z, int h)
-    {
-        if (!world.isRemote)
-        {
-            ItemStack equippedByPlayer = player.getCurrentEquippedItem();
-            if (equippedByPlayer != null && equippedByPlayer.getItem() instanceof ItemPickaxe && Enum.valueOf(Item.ToolMaterial.class, ((ItemPickaxe) equippedByPlayer.getItem()).getToolMaterialName()).getHarvestLevel() >= 2)
-                super.harvestBlock(world, player, x, y, z, h);
-        }
     }
 }

--- a/src/main/java/net/ilexiconn/jurassicraft/block/BlockAmberOre.java
+++ b/src/main/java/net/ilexiconn/jurassicraft/block/BlockAmberOre.java
@@ -17,7 +17,7 @@ public class BlockAmberOre extends Block
 {
     public BlockAmberOre()
     {
-        super(Material.ground);
+        super(Material.rock);
         setBlockName("amber_ore");
         setBlockTextureName(JurassiCraft.getModId() + "amber_ore");
         setHardness(3.0F);

--- a/src/main/java/net/ilexiconn/jurassicraft/block/BlockFossilClayOre.java
+++ b/src/main/java/net/ilexiconn/jurassicraft/block/BlockFossilClayOre.java
@@ -48,7 +48,7 @@ public class BlockFossilClayOre extends Block
         setResistance(5.0F);
         setCreativeTab(ModCreativeTabs.blocks);
         setStepSound(Block.soundTypeStone);
-        setHarvestLevel("pickaxe", 0);
+        setHarvestLevel("pickaxe", 2);
     }
 
     @Override
@@ -108,17 +108,6 @@ public class BlockFossilClayOre extends Block
         else
         {
             return ModItems.fossil;
-        }
-    }
-
-    @Override
-    public void harvestBlock(World world, EntityPlayer player, int x, int y, int z, int h)
-    {
-        if (!world.isRemote)
-        {
-            ItemStack equippedByPlayer = player.getCurrentEquippedItem();
-            if (equippedByPlayer != null && equippedByPlayer.getItem() instanceof ItemPickaxe && Enum.valueOf(Item.ToolMaterial.class, ((ItemPickaxe) equippedByPlayer.getItem()).getToolMaterialName()).getHarvestLevel() >= 2)
-                super.harvestBlock(world, player, x, y, z, h);
         }
     }
 

--- a/src/main/java/net/ilexiconn/jurassicraft/block/BlockFossilOre.java
+++ b/src/main/java/net/ilexiconn/jurassicraft/block/BlockFossilOre.java
@@ -45,7 +45,7 @@ public class BlockFossilOre extends Block
         setResistance(5.0F);
         setCreativeTab(ModCreativeTabs.blocks);
         setStepSound(Block.soundTypeStone);
-        setHarvestLevel("pickaxe", 0);
+        setHarvestLevel("pickaxe", 2);
     }
 
     public Item getItemDropped(int value, Random random, int thing)
@@ -66,16 +66,6 @@ public class BlockFossilOre extends Block
         else
         {
             return ModItems.fossil;
-        }
-    }
-
-    public void harvestBlock(World world, EntityPlayer player, int x, int y, int z, int h)
-    {
-        if (!world.isRemote)
-        {
-            ItemStack equippedByPlayer = player.getCurrentEquippedItem();
-            if (equippedByPlayer != null && equippedByPlayer.getItem() instanceof ItemPickaxe && Enum.valueOf(Item.ToolMaterial.class, ((ItemPickaxe) equippedByPlayer.getItem()).getToolMaterialName()).getHarvestLevel() >= 2)
-                super.harvestBlock(world, player, x, y, z, h);
         }
     }
 

--- a/src/main/java/net/ilexiconn/jurassicraft/block/BlockFossilOre.java
+++ b/src/main/java/net/ilexiconn/jurassicraft/block/BlockFossilOre.java
@@ -38,7 +38,7 @@ public class BlockFossilOre extends Block
 
     public BlockFossilOre()
     {
-        super(Material.ground);
+        super(Material.rock);
         setBlockName("fossil_ore");
         setBlockTextureName(JurassiCraft.getModId() + "fossil_ore");
         setHardness(3.0F);

--- a/src/main/java/net/ilexiconn/jurassicraft/block/BlockFossilSandstoneOre.java
+++ b/src/main/java/net/ilexiconn/jurassicraft/block/BlockFossilSandstoneOre.java
@@ -26,7 +26,7 @@ public class BlockFossilSandstoneOre extends Block
 
     public BlockFossilSandstoneOre()
     {
-        super(Material.ground);
+        super(Material.rock);
         setBlockName("fossil_sandstone_ore");
         setBlockTextureName(JurassiCraft.getModId() + "fossil_sandstone_ore");
         setHardness(3.0F);

--- a/src/main/java/net/ilexiconn/jurassicraft/block/BlockFossilSandstoneOre.java
+++ b/src/main/java/net/ilexiconn/jurassicraft/block/BlockFossilSandstoneOre.java
@@ -33,7 +33,7 @@ public class BlockFossilSandstoneOre extends Block
         setResistance(5.0F);
         setCreativeTab(ModCreativeTabs.blocks);
         setStepSound(Block.soundTypeStone);
-        setHarvestLevel("pickaxe", 0);
+        setHarvestLevel("pickaxe", 2);
     }
 
     public Item getItemDropped(int value, Random random, int thing)
@@ -54,16 +54,6 @@ public class BlockFossilSandstoneOre extends Block
         else
         {
             return ModItems.fossil;
-        }
-    }
-
-    public void harvestBlock(World world, EntityPlayer player, int x, int y, int z, int h)
-    {
-        if (!world.isRemote)
-        {
-            ItemStack equippedByPlayer = player.getCurrentEquippedItem();
-            if (equippedByPlayer != null && equippedByPlayer.getItem() instanceof ItemPickaxe && Enum.valueOf(Item.ToolMaterial.class, ((ItemPickaxe) equippedByPlayer.getItem()).getToolMaterialName()).getHarvestLevel() >= 2)
-                super.harvestBlock(world, player, x, y, z, h);
         }
     }
 

--- a/src/main/java/net/ilexiconn/jurassicraft/block/carboniferous/BlockCustomTallGrass.java
+++ b/src/main/java/net/ilexiconn/jurassicraft/block/carboniferous/BlockCustomTallGrass.java
@@ -52,11 +52,6 @@ public class BlockCustomTallGrass extends BlockFlower implements IShearable {
     }
 
     @Override
-    public void harvestBlock(World par1World, EntityPlayer par2EntityPlayer, int par3, int par4, int par5, int par6) {
-        super.harvestBlock(par1World, par2EntityPlayer, par3, par4, par5, par6);
-    }
-    
-    @Override
     public int getDamageValue(World par1World, int par2, int par3, int par4) {
         return par1World.getBlockMetadata(par2, par3, par4);
     }

--- a/src/main/java/net/ilexiconn/jurassicraft/block/carboniferous/BlockLeaves.java
+++ b/src/main/java/net/ilexiconn/jurassicraft/block/carboniferous/BlockLeaves.java
@@ -262,17 +262,6 @@ public class BlockLeaves extends BlockLeavesBase implements IShearable
     }
 
     /**
-     * Called when the player destroys a block with an item that can harvest it. (i, j, k) are the coordinates of the
-     * block and l is the block's subtype/damage.
-     */
-    public void harvestBlock(World p_149636_1_, EntityPlayer p_149636_2_, int p_149636_3_, int p_149636_4_, int p_149636_5_, int p_149636_6_)
-    {
-        {
-            super.harvestBlock(p_149636_1_, p_149636_2_, p_149636_3_, p_149636_4_, p_149636_5_, p_149636_6_);
-        }
-    }
-
-    /**
      * Determines the damage on the item the block drops. Used in cloth and wood.
      */
     public int damageDropped(int p_149692_1_)

--- a/src/main/java/net/ilexiconn/jurassicraft/block/carboniferous/BlockVine.java
+++ b/src/main/java/net/ilexiconn/jurassicraft/block/carboniferous/BlockVine.java
@@ -420,17 +420,6 @@ public class BlockVine extends Block implements IShearable
         return 0;
     }
 
-    /**
-     * Called when the player destroys a block with an item that can harvest it. (i, j, k) are the coordinates of the
-     * block and l is the block's subtype/damage.
-     */
-    public void harvestBlock(World p_149636_1_, EntityPlayer p_149636_2_, int p_149636_3_, int p_149636_4_, int p_149636_5_, int p_149636_6_)
-    {
-        {
-            super.harvestBlock(p_149636_1_, p_149636_2_, p_149636_3_, p_149636_4_, p_149636_5_, p_149636_6_);
-        }
-    }
-
     @Override
     public boolean isShearable(ItemStack item, IBlockAccess world, int x, int y, int z)
     {


### PR DESCRIPTION
It appears that the correct way to ensure that this can be harvested by Iron Pickaxe and above is to set the material type to "rock" and do setHarvestLevel("pickaxe", 2).

Also deleting a few completely redundant harvestBlock overrides I saw in a search that just call the base method with the same args.